### PR TITLE
Redirects to frontpage if valid redirect not set

### DIFF
--- a/pages/subscriber-reduced-price.php
+++ b/pages/subscriber-reduced-price.php
@@ -7,11 +7,11 @@ include __DIR__ . '/partials/head.php';
 
 if(!Plugin::instance()->settings->get_setting_value('subscriber_valid_redirect_url'))
 {
-    wp_redirect( home_url() );
+    wp_redirect(home_url());
+    ob_end_flush();
     exit;
 }
 
 if(!SubscriberReducedPricePage::isAuthenticated()) {
     include __DIR__ . '/partials/subscripber-reduced-price/authenticateSubscriber.php';
 }
-

--- a/pages/subscriber-reduced-price.php
+++ b/pages/subscriber-reduced-price.php
@@ -1,8 +1,15 @@
 <?php
 
+use Bonnier\WP\WypeResetpassword\Plugin;
 use Bonnier\WP\WypeResetpassword\Http\Routes\SubscriberReducedPricePage;
 
 include __DIR__ . '/partials/head.php';
+
+if(!Plugin::instance()->settings->get_setting_value('subscriber_valid_redirect_url'))
+{
+    wp_redirect( home_url() );
+    exit;
+}
 
 if(!SubscriberReducedPricePage::isAuthenticated()) {
     include __DIR__ . '/partials/subscripber-reduced-price/authenticateSubscriber.php';


### PR DESCRIPTION
When we are rolling out this new feature with subscription validation, then it must work for every country. Therefor I now checks if the setting `subscriber_valid_redirect_url` is set. If not, they can't see the reduced price page.